### PR TITLE
Add 'connectSocketTimeout' to reduce socket timeout during tryConnect()

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -112,6 +112,15 @@ public enum PGProperty {
     new String[] {"true", "false"}),
 
   /**
+   * The timeout value used for socket read operations while connecting to server.
+   * The timeout is specified in seconds. When value is zero then 'socketTimeout' will be used.
+   */
+  CONNECT_SOCKET_TIMEOUT(
+          "connectSocketTimeout",
+          "0",
+          "The timeout value used for socket read operations while connecting to server."),
+
+  /**
    * <p>The timeout value used for socket connect operations. If connecting to the server takes longer
    * than this value, the connection is broken.</p>
    *

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -332,6 +332,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @return connect socket timeout
+   * @see PGProperty#CONNECT_SOCKET_TIMEOUT
+   */
+  public int getConnectSocketTimeout() {
+    return PGProperty.CONNECT_SOCKET_TIMEOUT.getIntNoCheck(properties);
+  }
+
+  /**
+   * @param connectSocketTimeout connect timeout
+   * @see PGProperty#CONNECT_SOCKET_TIMEOUT
+   */
+  public void setConnectSocketTimeout(int connectSocketTimeout) {
+    PGProperty.CONNECT_SOCKET_TIMEOUT.set(properties, connectSocketTimeout);
+  }
+
+  /**
    * @return connect timeout
    * @see PGProperty#CONNECT_TIMEOUT
    */


### PR DESCRIPTION
This is connected with PR [#1584](https://github.com/pgjdbc/pgjdbc/pull/1584).
Now 'socketTimeout' property is a global query timeout, so we can't set it too low.
But on network split, it is possible that creation of a new connection
will stick on reading response from one of candidate hosts (like in PR above)
for a long time (our big 'socketTimeout').
The simplest solution is to decrease socket timeout during connection phase, and then restore it.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite in alphabetical order?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
